### PR TITLE
AH/v/78 play pause button assimilating their fellows

### DIFF
--- a/Phone/app/src/main/java/com/facilitation/phone/utility/BluetoothServer.kt
+++ b/Phone/app/src/main/java/com/facilitation/phone/utility/BluetoothServer.kt
@@ -83,7 +83,7 @@ class BluetoothServer(private val appContext: Application, private val activity 
             Log.i("VuzixSidekick", "Socket connection closed")
         }
         catch (e : IOException) {
-            Log.e("VuzixSidekick", "Socket crashed.")
+            Log.e("VuzixSidekick", "Socket crashed. \nThe reason:\n${e.stackTrace}")
             e.printStackTrace()
         }
             Looper.loop()

--- a/Phone/app/src/main/java/com/facilitation/phone/utility/SocketHandler.kt
+++ b/Phone/app/src/main/java/com/facilitation/phone/utility/SocketHandler.kt
@@ -44,7 +44,7 @@ class SocketHandler(private val context: Context) {
             Thread {
                 Looper.prepare()
                 when {
-                    "track" in command -> spotifyRemote.playerApi.play(command)
+                    "track" in command -> playTrackInPlaylist(command)
                     "pause" in command -> spotifyRemote.playerApi.pause()
                     "resume" in command -> spotifyRemote.playerApi.resume()
                     "playlist" in command -> sendTracksDTO(socket)
@@ -66,5 +66,11 @@ class SocketHandler(private val context: Context) {
         } catch (e: IOException) {
             e.printStackTrace()
         }
+    }
+    private fun playTrackInPlaylist(position: String) {
+        val playlist = context.getString(R.string.playlistID)
+        val finalCommand = "spotify:playlist:$playlist"
+        val songPosition = position.replace("track:", "")
+        spotifyRemote.playerApi.skipToIndex(finalCommand, songPosition.toInt())
     }
 }

--- a/Phone/app/src/main/java/com/facilitation/phone/utility/SocketHandler.kt
+++ b/Phone/app/src/main/java/com/facilitation/phone/utility/SocketHandler.kt
@@ -47,6 +47,8 @@ class SocketHandler(private val context: Context) {
                     "track" in command -> playTrackInPlaylist(command)
                     "pause" in command -> spotifyRemote.playerApi.pause()
                     "resume" in command -> spotifyRemote.playerApi.resume()
+                    "previous" in command -> spotifyRemote.playerApi.skipPrevious()
+                    "next" in command -> spotifyRemote.playerApi.skipNext()
                     "playlist" in command -> sendTracksDTO(socket)
                     else -> Log.e("VuzixSidekick", "I got command \"$command\" and I don't know what to do with it")
                 }

--- a/Phone/app/src/main/res/values/strings.xml
+++ b/Phone/app/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="client_secret">570f169fa60a4a91a7f5d493a251f41b</string>
     <string name="redirect_uri">http://localhost:8888/callback/</string>
     <string name="playlist_uri">https://api.spotify.com/v1/playlists/04wwOyhtie5aEUbvMdAOii?si=e2b67652ad034ce4/tracks</string>
+    <string name="userID">reimantas.tiuninas</string>
+    <string name="playlistID">04wwOyhtie5aEUbvMdAOii</string>
     <string name="request_code">9485</string>
     <!-- Strings related to login -->
     <string name="action_sign_in">Sign in</string>

--- a/Vuzix/app/src/main/java/com/facilitation/view/activities/MainActivity.kt
+++ b/Vuzix/app/src/main/java/com/facilitation/view/activities/MainActivity.kt
@@ -89,18 +89,19 @@ class MainActivity : ActionMenuActivity(), ITapInput {
         //TODO: Filter here on action int in the KeyEvent constructor to differentiate between different view mappings - Aldís 11.10.23
         when (event.keyCode) {
             KeyEvent.KEYCODE_ENTER -> {
-                Log.d("Key Event INFO", "Selecting ${currentMenuItem.title}\n------> ${TapToCommandEnum.XXOOO.keyCode()}")
                 select()
                 return true
             }
             KeyEvent.KEYCODE_BACK -> {
-                Log.d("Key Event INFO", "Going left\n------> ${TapToCommandEnum.XOXOO.keyCode()}")
                 goLeft()
                 return true
             }
             KeyEvent.KEYCODE_FORWARD -> {
-                Log.d("Key Event INFO", "Going right\n------> ${TapToCommandEnum.XOOXO.keyCode()}")
                 goRight()
+                return true
+            }
+            KeyEvent.KEYCODE_ESCAPE -> {
+                goBack()
                 return true
             }
             KeyEvent.KEYCODE_DPAD_UP -> {

--- a/Vuzix/app/src/main/java/com/facilitation/view/activities/spotify/SpotifyListActivity.kt
+++ b/Vuzix/app/src/main/java/com/facilitation/view/activities/spotify/SpotifyListActivity.kt
@@ -67,10 +67,18 @@ class SpotifyListActivity : AppCompatActivity(), ITapInput {
         requestPlaylist()
     }
 
+    @SuppressLint("NotifyDataSetChanged")
+    override fun onResume() {
+        spotifyListAdapter.notifyDataSetChanged()
+        super.onResume()
+    }
+
     fun playSongFromList(view: View) {
         playlistPosition = recyclerView.getChildLayoutPosition(view)
         if (playlistPosition != RecyclerView.NO_POSITION) {
-            playSelectedSong()
+            sendBluetoothCommand("track:$playlistPosition")
+            showToast("Playing ${trackDTOList[playlistPosition].title}")
+            showSpotifySongActivity()
         }
     }
 
@@ -95,13 +103,6 @@ class SpotifyListActivity : AppCompatActivity(), ITapInput {
         return bluetoothHandler!!.sendReturnableCommand(command)
     }
 
-    private fun playSelectedSong() {
-        val selectedTrack = trackDTOList.get(playlistPosition)
-        sendBluetoothCommand(selectedTrack.uri)
-        showToast("Now playing: ${selectedTrack.title}")
-        showSpotifySongActivity(selectedTrack)
-    }
-
     private fun showToast(text: String) {
         val activity: Activity = this
         activity.runOnUiThread { Toast.makeText(activity, text, Toast.LENGTH_SHORT).show() }
@@ -115,11 +116,10 @@ class SpotifyListActivity : AppCompatActivity(), ITapInput {
         recyclerView.adapter?.notifyDataSetChanged()
     }
 
-    private fun showSpotifySongActivity(selectedTrack: TrackDTO) {
+    private fun showSpotifySongActivity() {
         //TODO: Pass Spotify state to SongActivity - Jody 08.11.23
         val intent = Intent(this, SpotifySongActivity::class.java)
         intent.putExtra("callback", activityLifecycleCallbacks)
-        //intent.putExtra("song", selectedTrack)
         startActivity(intent)
     }
 

--- a/Vuzix/app/src/main/java/com/facilitation/view/activities/spotify/SpotifyListActivity.kt
+++ b/Vuzix/app/src/main/java/com/facilitation/view/activities/spotify/SpotifyListActivity.kt
@@ -124,6 +124,10 @@ class SpotifyListActivity : AppCompatActivity(), ITapInput {
     }
 
     override fun onInputReceived(commandEnum: TapToCommandEnum) {
+        if (commandEnum == TapToCommandEnum.OXXXX) {
+            goBack()
+            return
+        }
         inputMethodManager.dispatchKeyEventFromInputMethod(binding.root, KeyEvent(KeyEvent.ACTION_DOWN, commandEnum.keyCode()))
         inputMethodManager.dispatchKeyEventFromInputMethod(binding.root, KeyEvent(KeyEvent.ACTION_UP, commandEnum.keyCode()))
     }
@@ -155,7 +159,7 @@ class SpotifyListActivity : AppCompatActivity(), ITapInput {
             startActivity(intent)
         }
         catch (e:Exception) {
-            Log.e("Spotify menu ERROR", "Error going back in Spotify menu:\n ${e.message}")
+            Log.e("Spotify menu ERROR", "Error going back in Spotify playlist:\n ${e.message}")
         }
     }
 }

--- a/Vuzix/app/src/main/java/com/facilitation/view/activities/spotify/SpotifySongActivity.kt
+++ b/Vuzix/app/src/main/java/com/facilitation/view/activities/spotify/SpotifySongActivity.kt
@@ -1,6 +1,5 @@
 package com.facilitation.view.activities.spotify
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.bluetooth.BluetoothAdapter
 import android.content.Context
@@ -25,7 +24,6 @@ import com.google.gson.Gson
 import com.vuzix.hud.actionmenu.ActionMenuActivity
 
 class SpotifySongActivity : ActionMenuActivity(), ITapInput {
-    private var playlistPosition: Int = 0
     private val gson = Gson()
     private lateinit var binding : ActivitySpotifySongBinding
     private lateinit var PlayPauseMenuItem: MenuItem
@@ -94,10 +92,7 @@ class SpotifySongActivity : ActionMenuActivity(), ITapInput {
     }
 
     fun previousSong(item: MenuItem?) {
-        //TODO: Is functional, just needs the playlist from the List Activity - Jody 08.11.23
-//        playlistPosition--
-//        playlistPosition = (playlistPosition + trackDTOList.size) % trackDTOList.size
-//        playSelectedSong()
+        sendBluetoothCommand("previous")
     }
 
     fun togglePlayPause(item: MenuItem?) {
@@ -112,10 +107,7 @@ class SpotifySongActivity : ActionMenuActivity(), ITapInput {
     }
 
     fun nextSong(item: MenuItem?) {
-        //TODO: Is functional, just needs the playlist from the List Activity - Jody 08.11.23
-//        playlistPosition++
-//        playlistPosition = playlistPosition % trackDTOList.size
-//        playSelectedSong()
+        sendBluetoothCommand("next")
     }
 
     fun showSongDetails(item: MenuItem?) {

--- a/Vuzix/app/src/main/java/com/facilitation/view/activities/spotify/SpotifySongActivity.kt
+++ b/Vuzix/app/src/main/java/com/facilitation/view/activities/spotify/SpotifySongActivity.kt
@@ -162,7 +162,7 @@ class SpotifySongActivity : ActionMenuActivity(), ITapInput {
                 return true
             }
             KeyEvent.KEYCODE_SPACE -> {
-                this.togglePlayPause(currentMenuItem)
+                this.togglePlayPause(PlayPauseMenuItem)
                 return true
             }
         }


### PR DESCRIPTION
Features:
- Playing track in playlist context instead of radio mode, so when the song finishes, it will play the next song in the playlist
- Playing next & previous songs on the list by button click
- Back Tap navigation to playlist & main
  - Added if statement before delegation to the framework in onInputReceived in playlist activity to call goBack method

Bugfix:
- In spotify song activity tapping the first three fingers (keycode for space) changes the current menu item icon into a play/pause icon.
- Fix was passing the PlayPauseMenuItem as argument in the switch case instead of the current menu item